### PR TITLE
Fix navigation flows and add story editing

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -80,6 +80,11 @@ const AssessmentResultsScreen = lazyScreenWithSkeleton(
   'assessment',
   'Analyzing results...'
 );
+const AssessmentResultsScreen_Premium = lazyScreenWithSkeleton(
+  () => import("../screens/assessment/AssessmentResultsScreen_Premium").then(m => ({ default: m.AssessmentResultsScreen })),
+  'assessment',
+  'Preparing premium insights...'
+);
 const AssessmentRecommendationsScreen = lazyScreenWithSkeleton(
   () => import("../screens/assessment/AssessmentRecommendationsScreen").then(m => ({ default: m.AssessmentRecommendationsScreen })),
   'assessment',
@@ -89,6 +94,33 @@ const PairComparisonScreen = lazyScreenWithSkeleton(
   () => import("../screens/assessment/PairComparisonScreen").then(m => ({ default: m.PairComparisonScreen })),
   'assessment',
   'Loading comparison...'
+);
+
+const PremiumDashboardScreen = lazyScreenWithSkeleton(
+  () => import("../screens/premium/PremiumDashboardScreen").then(m => ({ default: m.PremiumDashboardScreen })),
+  'premium',
+  'Loading premium analytics...'
+);
+
+const StoriesScreen = lazyScreenWithSkeleton(
+  () => import("../screens/stories/StoriesScreen").then(m => ({ default: m.StoriesScreen })),
+  'generic',
+  'Loading stories...'
+);
+const CreateStoryScreen = lazyScreenWithSkeleton(
+  () => import("../screens/stories/CreateStoryScreen").then(m => ({ default: m.CreateStoryScreen })),
+  'generic',
+  'Preparing story editor...'
+);
+const StoryDetailScreen = lazyScreenWithSkeleton(
+  () => import("../screens/stories/StoryDetailScreen").then(m => ({ default: m.StoryDetailScreen })),
+  'generic',
+  'Loading story details...'
+);
+const EditStoryScreen = lazyScreenWithSkeleton(
+  () => import("../screens/stories/EditStoryScreen").then(m => ({ default: m.EditStoryScreen })),
+  'generic',
+  'Preparing story editor...'
 );
 
 // Story Screens removed - integrated into Twincidence Log
@@ -152,11 +184,12 @@ type RootStackParamList = {
   AssessmentSurvey: undefined;
   AssessmentLoading: { responses: Record<number, number> };
   AssessmentResults: { results: any };
-  AssessmentRecommendations: { results: any };
+  AssessmentRecommendations: { results?: any; sessionId?: string };
   PairComparison: undefined;
   // Premium screens
   Premium: { feature?: string; source?: 'assessment' | 'settings' | 'dashboard' | 'onboarding' };
   PremiumFeatures: undefined;
+  PremiumDashboard: undefined;
   // Story screens removed - integrated into Twincidence Log
   // Missing routes identified in navigation calls
   GameStats: undefined;
@@ -172,6 +205,11 @@ type RootStackParamList = {
   ResearchParticipation: undefined;
   // Pair route
   Pair: undefined;
+  // Story routes
+  Stories: undefined;
+  CreateStory: { draftId?: string } | undefined;
+  StoryDetail: { storyId: string };
+  EditStory: { storyId: string };
 };
 
 const TabNavigator = () => {
@@ -452,14 +490,15 @@ export const AppNavigator = () => {
             <Stack.Screen name="AssessmentRecommendations" component={AssessmentRecommendationsScreen} />
             <Stack.Screen name="PairComparison" component={PairComparisonScreen} />
             {/* Premium Screens */}
-            <Stack.Screen 
-              name="Premium" 
+            <Stack.Screen
+              name="Premium"
               component={PremiumScreen}
             />
-            <Stack.Screen 
-              name="PremiumFeatures" 
+            <Stack.Screen
+              name="PremiumFeatures"
               component={PremiumScreen}
             />
+            <Stack.Screen name="PremiumDashboard" component={PremiumDashboardScreen} />
             {/* Twin Connection Game Screens */}
             <Stack.Screen name="TwinGamesHub" component={TwinGamesHub} />
             <Stack.Screen name="CognitiveSyncMaze" component={CognitiveSyncMaze} />
@@ -481,8 +520,13 @@ export const AppNavigator = () => {
             <Stack.Screen name="Home" component={TabNavigator} />
             <Stack.Screen name="Settings" component={SettingsScreen} />
             <Stack.Screen name="Recommendations" component={AssessmentRecommendationsScreen} />
-            <Stack.Screen name="AssessmentDetails" component={AssessmentResultsScreen} />
+            <Stack.Screen name="AssessmentDetails" component={AssessmentResultsScreen_Premium} />
             <Stack.Screen name="Pair" component={require("../screens/PairScreen").PairScreen} />
+            {/* Story Screens */}
+            <Stack.Screen name="Stories" component={StoriesScreen} />
+            <Stack.Screen name="CreateStory" component={CreateStoryScreen} />
+            <Stack.Screen name="StoryDetail" component={StoryDetailScreen} />
+            <Stack.Screen name="EditStory" component={EditStoryScreen} />
           </>
         )}
       </Stack.Navigator>

--- a/src/screens/assessment/AssessmentResultsScreen.tsx
+++ b/src/screens/assessment/AssessmentResultsScreen.tsx
@@ -248,7 +248,7 @@ export const AssessmentResultsScreen = () => {
                 </Pressable>
                 
                 <Pressable
-                  onPress={() => navigation.navigate('AssessmentRecommendations', { results: session })}
+                  onPress={() => navigation.navigate('AssessmentRecommendations', { sessionId, results })}
                   className="bg-white/10 rounded-xl p-4 mb-3"
                 >
                   <Text className="text-white text-center font-medium">

--- a/src/screens/assessment/AssessmentResultsScreen_Premium.tsx
+++ b/src/screens/assessment/AssessmentResultsScreen_Premium.tsx
@@ -192,7 +192,7 @@ export const AssessmentResultsScreen = () => {
     if (!requireCoachingPlans(() => navigateToUpgrade('coaching_plans', 'recommendations_button'))) {
       return;
     }
-    navigation.navigate('AssessmentRecommendations', { sessionId });
+    navigation.navigate('AssessmentRecommendations', { sessionId, results });
   };
 
   const detailedResultsFeature = PREMIUM_FEATURES.find(f => f.id === 'detailed_results')!;

--- a/src/screens/assessment/PairComparisonScreen.tsx
+++ b/src/screens/assessment/PairComparisonScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { View, Text, Pressable, ScrollViewBackground } from "react-native";
 import { ImageBackground } from "expo-image";
 import { Image } from "expo-image";
@@ -118,6 +118,31 @@ export const PairComparisonScreen = () => {
   };
   
   const compatibilityScore = calculateCompatibility();
+
+  const recommendationLevel = useMemo(() => {
+    if (compatibilityScore >= 85) return 'Extraordinary';
+    if (compatibilityScore >= 70) return 'Strong';
+    if (compatibilityScore >= 55) return 'Moderate';
+    return 'Developing';
+  }, [compatibilityScore]);
+
+  const recommendationPayload = useMemo(() => ({
+    overallScore: Math.round((MOCK_TWIN_RESULTS.user.overallScore + MOCK_TWIN_RESULTS.twin.overallScore) / 2),
+    categoryScores: {
+      emotionalConnection: Math.round((MOCK_TWIN_RESULTS.user.categoryScores.emotionalConnection + MOCK_TWIN_RESULTS.twin.categoryScores.emotionalConnection) / 2),
+      telepathicExperiences: Math.round((MOCK_TWIN_RESULTS.user.categoryScores.telepathicExperiences + MOCK_TWIN_RESULTS.twin.categoryScores.telepathicExperiences) / 2),
+      behavioralSynchrony: Math.round((MOCK_TWIN_RESULTS.user.categoryScores.behavioralSynchrony + MOCK_TWIN_RESULTS.twin.categoryScores.behavioralSynchrony) / 2),
+      sharedExperiences: Math.round((MOCK_TWIN_RESULTS.user.categoryScores.sharedExperiences + MOCK_TWIN_RESULTS.twin.categoryScores.sharedExperiences) / 2),
+      physicalSensations: Math.round((MOCK_TWIN_RESULTS.user.categoryScores.physicalSensations + MOCK_TWIN_RESULTS.twin.categoryScores.physicalSensations) / 2),
+    },
+    level: recommendationLevel,
+    insights: COMPATIBILITY_INSIGHTS.map((insight) => insight.description),
+    recommendations: COMPATIBILITY_INSIGHTS.map((insight) => insight.description),
+  }), [recommendationLevel]);
+
+  const handleViewRecommendations = () => {
+    navigation.navigate('AssessmentRecommendations', { results: recommendationPayload });
+  };
   
   // Animation
   const fadeIn = useSharedValue(0);
@@ -333,8 +358,8 @@ export const PairComparisonScreen = () => {
 
             {/* Action Buttons */}
             <View className="space-y-3">
-              <Pressable 
-                onPress={() => navigation.navigate("AssessmentRecommendations" as never)}
+              <Pressable
+                onPress={handleViewRecommendations}
                 className="rounded-xl py-4 px-6 flex-row items-center justify-center"
                 style={{ backgroundColor: accentColor }}
               >

--- a/src/screens/premium/PremiumDashboardScreen.tsx
+++ b/src/screens/premium/PremiumDashboardScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, ScrollView, Pressable, Dimensions, ImageBackground } from 'react-native';
+import { View, Text, ScrollView, Pressable, Dimensions, ImageBackground, Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
@@ -130,7 +130,7 @@ const ProgressRing: React.FC<{
 export const PremiumDashboardScreen: React.FC = () => {
   const navigation = useNavigation<any>();
   const { userProfile, twinProfile } = useTwinStore();
-  const { getAllResults } = useAssessmentStore();
+  const getAllResults = useAssessmentStore((state) => state.getAllResults);
   
   const {
     canViewAdvancedAnalytics,
@@ -199,6 +199,28 @@ export const PremiumDashboardScreen: React.FC = () => {
     } catch (error) {
       console.error('Export failed:', error);
     }
+  };
+
+  const handleOpenRecommendations = () => {
+    const allResults = getAllResults();
+
+    if (!allResults || allResults.length === 0) {
+      Alert.alert(
+        'No assessments yet',
+        'Complete your first assessment to unlock personalized recommendations.',
+        [
+          { text: 'Later', style: 'cancel' },
+          { text: 'Start Assessment', onPress: () => navigation.navigate('AssessmentIntro') },
+        ]
+      );
+      return;
+    }
+
+    const latestResult = allResults[allResults.length - 1];
+    navigation.navigate('AssessmentRecommendations', {
+      sessionId: latestResult.sessionId,
+      results: latestResult,
+    });
   };
 
   return (
@@ -395,7 +417,7 @@ export const PremiumDashboardScreen: React.FC = () => {
               
               <View className="flex-row space-x-3">
                 <Pressable 
-                  onPress={() => navigation.navigate('AssessmentRecommendations')}
+                  onPress={handleOpenRecommendations}
                   className="flex-1 bg-white/10 rounded-xl p-3"
                 >
                   <Text className="text-white text-center font-medium">View Coaching</Text>

--- a/src/screens/stories/EditStoryScreen.tsx
+++ b/src/screens/stories/EditStoryScreen.tsx
@@ -1,0 +1,149 @@
+import React, { useMemo, useState } from 'react';
+import { View, Text, Pressable, Alert, ImageBackground } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
+
+import { StoryEditor } from '../../components/stories/StoryEditor';
+import { useStoryStore } from '../../state/stores/stories/storyStore';
+import { StoryDraft } from '../../types/stories';
+
+interface EditStoryRouteParams {
+  storyId?: string;
+}
+
+export const EditStoryScreen: React.FC = () => {
+  const navigation = useNavigation<any>();
+  const route = useRoute<any>();
+  const { storyId }: EditStoryRouteParams = route.params || {};
+
+  const { stories, updateStory } = useStoryStore();
+  const [isSaving, setIsSaving] = useState(false);
+
+  const story = stories.find((s) => s.id === storyId);
+
+  const editorDraft = useMemo<StoryDraft | undefined>(() => {
+    if (!story) return undefined;
+
+    return {
+      id: story.id,
+      title: story.title,
+      content: story.content,
+      category: story.category,
+      tags: story.tags,
+      media: story.media,
+      milestone: story.milestone,
+      location: story.location,
+      lastSaved: story.lastModified,
+      autoSaved: false,
+    };
+  }, [story]);
+
+  const handleSave = async (updatedStory: any) => {
+    if (!story) return;
+
+    setIsSaving(true);
+
+    try {
+      updateStory(story.id, {
+        title: updatedStory.title,
+        content: updatedStory.content,
+        category: updatedStory.category,
+        tags: updatedStory.tags,
+        media: updatedStory.media,
+        milestone: updatedStory.milestone,
+        location: updatedStory.location,
+      });
+
+      Alert.alert(
+        'Story Updated',
+        'Your story has been updated successfully.',
+        [
+          {
+            text: 'View Story',
+            onPress: () => navigation.replace('StoryDetail', { storyId: story.id }),
+          },
+          {
+            text: 'Done',
+            style: 'default',
+            onPress: () => navigation.goBack(),
+          },
+        ],
+        { cancelable: false }
+      );
+    } catch (error) {
+      console.error('Failed to update story:', error);
+      Alert.alert('Update Failed', 'Unable to update your story. Please try again.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    Alert.alert(
+      'Discard changes?',
+      'Any unsaved edits will be lost.',
+      [
+        { text: 'Keep Editing', style: 'cancel' },
+        { text: 'Discard', style: 'destructive', onPress: () => navigation.goBack() },
+      ]
+    );
+  };
+
+  if (!story || !editorDraft) {
+    return (
+      <ImageBackground source={require('../../assets/galaxybackground.png')} style={{ flex: 1 }}>
+        <SafeAreaView className="flex-1 items-center justify-center px-6">
+          <Ionicons name="book-outline" size={56} color="rgba(255,255,255,0.6)" />
+          <Text className="text-white text-xl font-semibold mt-4">Story unavailable</Text>
+          <Text className="text-white/70 text-center mt-2">
+            We couldn't find the story you're trying to edit.
+          </Text>
+          <Pressable
+            onPress={() => navigation.goBack()}
+            className="bg-purple-500 rounded-xl px-6 py-3 mt-6"
+          >
+            <Text className="text-white font-semibold">Go Back</Text>
+          </Pressable>
+        </SafeAreaView>
+      </ImageBackground>
+    );
+  }
+
+  return (
+    <ImageBackground source={require('../../assets/galaxybackground.png')} style={{ flex: 1 }}>
+      <SafeAreaView className="flex-1">
+        <View className="flex-row items-center justify-between px-6 py-4 border-b border-white/10">
+          <Pressable onPress={handleCancel} className="flex-row items-center">
+            <Ionicons name="arrow-back" size={24} color="white" />
+            <Text className="text-white text-lg font-medium ml-2">Cancel</Text>
+          </Pressable>
+
+          <Text className="text-white text-xl font-semibold">Edit Story</Text>
+
+          <View className="w-20" />
+        </View>
+
+        {isSaving && (
+          <View className="absolute inset-0 bg-black/50 items-center justify-center z-50">
+            <View className="bg-white/10 rounded-2xl p-8 items-center border border-white/20">
+              <View className="animate-spin mb-4">
+                <Ionicons name="sync" size={32} color="white" />
+              </View>
+              <Text className="text-white text-lg font-semibold">Updating Story...</Text>
+              <Text className="text-white/70 text-sm mt-1">Please wait while we save your changes</Text>
+            </View>
+          </View>
+        )}
+
+        <StoryEditor
+          draft={editorDraft}
+          onSave={handleSave}
+          onCancel={handleCancel}
+          autoSave={false}
+        />
+      </SafeAreaView>
+    </ImageBackground>
+  );
+};
+

--- a/src/state/assessmentStore.ts
+++ b/src/state/assessmentStore.ts
@@ -51,6 +51,7 @@ interface AssessmentState {
   canSubmit: () => boolean;
   getSessionById: (sessionId: string) => AssessmentSession | undefined;
   getResultsById: (sessionId: string) => AssessmentResults | undefined;
+  getAllResults: () => AssessmentResults[];
 }
 
 // Flatten all items from categories into a single array
@@ -285,6 +286,10 @@ export const useAssessmentStore = create<AssessmentState>()(
 
       getResultsById: (sessionId: string) => {
         return get().results.find(r => r.sessionId === sessionId);
+      },
+
+      getAllResults: () => {
+        return get().results;
       }
     }),
     {


### PR DESCRIPTION
## Summary
- add lazy-loaded story routes including a new edit flow so story navigation works end-to-end
- fix premium and assessment navigation targets and normalize recommendation data retrieval across the app
- expose assessment store getters for dashboard use and wire premium/pair comparison buttons to correct destinations

## Testing
- `npm run lint` *(fails: ESLint requires migrating to eslint.config.js)*
- `npm run typecheck` *(fails: missing Jest globals/types in existing test files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0231ce510832c8ae910d632ad3261