### PR TITLE
Ensure sign out clears support state

### DIFF
--- a/src/state/supportStore.ts
+++ b/src/state/supportStore.ts
@@ -1,0 +1,146 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+export type SupportMessageAuthor = "user" | "support" | "system";
+
+export interface SupportMessage {
+  id: string;
+  sender: SupportMessageAuthor;
+  content: string;
+  timestamp: string;
+  read: boolean;
+  attachments?: Array<{
+    id: string;
+    uri: string;
+    type: string;
+    name?: string;
+  }>;
+}
+
+export type SupportTicketStatus = "open" | "pending" | "resolved" | "closed";
+export type SupportTicketPriority = "low" | "medium" | "high";
+
+export interface SupportTicket {
+  id: string;
+  subject: string;
+  status: SupportTicketStatus;
+  priority: SupportTicketPriority;
+  createdAt: string;
+  updatedAt: string;
+  messages: SupportMessage[];
+  lastAgentName?: string;
+  satisfactionScore?: number | null;
+}
+
+export interface SupportStateSnapshot {
+  tickets: SupportTicket[];
+  activeTicketId: string | null;
+  unreadCount: number;
+  isSyncing: boolean;
+  lastSyncedAt: string | null;
+  error: string | null;
+}
+
+interface SupportActions {
+  setTickets: (tickets: SupportTicket[]) => void;
+  upsertTicket: (ticket: SupportTicket) => void;
+  addMessageToTicket: (ticketId: string, message: SupportMessage) => void;
+  setActiveTicket: (ticketId: string | null) => void;
+  markTicketRead: (ticketId: string) => void;
+  setUnreadCount: (count: number) => void;
+  setIsSyncing: (isSyncing: boolean) => void;
+  setLastSyncedAt: (timestamp: string | null) => void;
+  setError: (error: string | null) => void;
+  reset: () => void;
+}
+
+export type SupportState = SupportStateSnapshot & SupportActions;
+
+const createInitialSnapshot = (): SupportStateSnapshot => ({
+  tickets: [],
+  activeTicketId: null,
+  unreadCount: 0,
+  isSyncing: false,
+  lastSyncedAt: null,
+  error: null,
+});
+
+const initialSnapshot = createInitialSnapshot();
+
+export const getInitialSupportStateSnapshot = (): SupportStateSnapshot =>
+  createInitialSnapshot();
+
+export const useSupportStore = create<SupportState>()(
+  persist(
+    (set) => ({
+      ...initialSnapshot,
+      setTickets: (tickets) => set({ tickets }),
+      upsertTicket: (ticket) =>
+        set((state) => {
+          const index = state.tickets.findIndex((entry) => entry.id === ticket.id);
+          if (index >= 0) {
+            const updatedTickets = state.tickets.slice();
+            updatedTickets[index] = { ...updatedTickets[index], ...ticket };
+            return { tickets: updatedTickets };
+          }
+
+          return { tickets: [ticket, ...state.tickets] };
+        }),
+      addMessageToTicket: (ticketId, message) =>
+        set((state) => {
+          const tickets = state.tickets.map((ticket) =>
+            ticket.id === ticketId
+              ? {
+                  ...ticket,
+                  messages: [...ticket.messages, message],
+                  updatedAt: message.timestamp,
+                  status:
+                    message.sender === "support" && ticket.status === "resolved"
+                      ? "open"
+                      : ticket.status,
+                }
+              : ticket,
+          );
+
+          const unreadCount =
+            message.sender === "support"
+              ? state.unreadCount + 1
+              : state.unreadCount;
+
+          return { tickets, unreadCount };
+        }),
+      setActiveTicket: (ticketId) => set({ activeTicketId: ticketId }),
+      markTicketRead: (ticketId) =>
+        set((state) => ({
+          tickets: state.tickets.map((ticket) =>
+            ticket.id === ticketId
+              ? {
+                  ...ticket,
+                  messages: ticket.messages.map((message) => ({
+                    ...message,
+                    read: true,
+                  })),
+                }
+              : ticket,
+          ),
+          unreadCount: 0,
+        })),
+      setUnreadCount: (count) => set({ unreadCount: Math.max(0, count) }),
+      setIsSyncing: (isSyncing) => set({ isSyncing }),
+      setLastSyncedAt: (timestamp) => set({ lastSyncedAt: timestamp }),
+      setError: (error) => set({ error }),
+      reset: () => set(() => createInitialSnapshot()),
+    }),
+    {
+      name: "twin-support-store",
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({
+        tickets: state.tickets,
+        activeTicketId: state.activeTicketId,
+        unreadCount: state.unreadCount,
+        lastSyncedAt: state.lastSyncedAt,
+      }),
+    },
+  ),
+);

--- a/src/state/twinStore.ts
+++ b/src/state/twinStore.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { shallow } from "zustand/shallow";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useSupportStore } from "./supportStore";
 
 export type TwinType = "identical" | "fraternal" | "other";
 export type ThemeColor = "neon-pink" | "neon-blue" | "neon-green" | "neon-yellow" | "neon-purple" | "neon-orange" | "neon-cyan" | "neon-red";
@@ -220,27 +221,38 @@ export const useTwinStore = create<TwinState>()(
         twinProfile: get().twinProfile ? { ...get().twinProfile!, isConnected: value } : null,
       }),
       
-      signOut: () => set({ 
-        isOnboarded: false,
-        userProfile: null,
-        twinProfile: null,
-        themeColor: "neon-purple",
-        shareCode: null,
-        paired: false,
-        pendingInvitation: null,
-        invitationToken: null,
-        invitationStatus: 'none',
-        lastInvitationSent: null,
-        invitationHistory: [],
-        twintuitionAlerts: [],
-        gameResults: [],
-        stories: [],
-        syncScore: 0,
-        researchParticipation: false,
-        notificationsEnabled: true,
-        hasActiveResearchStudies: false,
-        researchContributions: 0,
-      }),
+      signOut: () => {
+        const { reset: resetSupportStore } = useSupportStore.getState();
+        if (typeof resetSupportStore === "function") {
+          resetSupportStore();
+        }
+
+        AsyncStorage.removeItem("twin-support-store").catch((error) => {
+          console.error("Failed to clear support storage", error);
+        });
+
+        set({
+          isOnboarded: false,
+          userProfile: null,
+          twinProfile: null,
+          themeColor: "neon-purple",
+          shareCode: null,
+          paired: false,
+          pendingInvitation: null,
+          invitationToken: null,
+          invitationStatus: 'none',
+          lastInvitationSent: null,
+          invitationHistory: [],
+          twintuitionAlerts: [],
+          gameResults: [],
+          stories: [],
+          syncScore: 0,
+          researchParticipation: false,
+          notificationsEnabled: true,
+          hasActiveResearchStudies: false,
+          researchContributions: 0,
+        });
+      },
       
       addTwintuitionAlert: (alert) => {
         const newAlert: TwintuitionAlert = {

--- a/src/tests/__tests__/twinStoreSignOut.test.ts
+++ b/src/tests/__tests__/twinStoreSignOut.test.ts
@@ -1,0 +1,71 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useTwinStore } from "../../state/twinStore";
+import {
+  useSupportStore,
+  getInitialSupportStateSnapshot,
+  SupportMessage,
+  SupportTicket,
+} from "../../state/supportStore";
+
+const getSupportStateSnapshot = () => {
+  const {
+    tickets,
+    activeTicketId,
+    unreadCount,
+    isSyncing,
+    lastSyncedAt,
+    error,
+  } = useSupportStore.getState();
+
+  return { tickets, activeTicketId, unreadCount, isSyncing, lastSyncedAt, error };
+};
+
+describe("useTwinStore signOut", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useSupportStore.getState().reset();
+  });
+
+  it("resets the support store and clears persisted storage", () => {
+    const messageHistory: SupportMessage[] = [
+      {
+        id: "message-1",
+        sender: "user",
+        content: "I need help with the app",
+        timestamp: "2024-01-01T00:00:00.000Z",
+        read: true,
+      },
+      {
+        id: "message-2",
+        sender: "support",
+        content: "We're looking into this for you",
+        timestamp: "2024-01-01T01:00:00.000Z",
+        read: false,
+      },
+    ];
+
+    const supportTicket: SupportTicket = {
+      id: "ticket-1",
+      subject: "Twinship support request",
+      status: "open",
+      priority: "high",
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T01:00:00.000Z",
+      messages: messageHistory,
+    };
+
+    useSupportStore.setState({
+      tickets: [supportTicket],
+      activeTicketId: supportTicket.id,
+      unreadCount: 5,
+      isSyncing: true,
+      lastSyncedAt: "2024-01-01T02:00:00.000Z",
+      error: "Network error",
+    });
+
+    useTwinStore.getState().signOut();
+
+    expect(getSupportStateSnapshot()).toEqual(getInitialSupportStateSnapshot());
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith("twin-support-store");
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated support store with reset helpers and persisted storage
- update twin sign-out to reset the support store and drop the persisted support key
- cover the new behaviour with a Jest test that ensures support data is cleared on sign-out

## Testing
- `npm test -- twinStoreSignOut` *(fails: local Jest binary unavailable before dependencies are installed; `npm install` is blocked by 403 errors fetching react-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68da84f0e9e4832caf53e0822cace77c